### PR TITLE
Ignore inapplicable gRNA assignment arguments

### DIFF
--- a/bin/assign_grnas.R
+++ b/bin/assign_grnas.R
@@ -7,13 +7,8 @@ response_odm_fp <- args[2]
 grna_odm_fp <- args[3]
 grna_to_pod_map_fp <- args[4]
 grna_pod <- as.integer(args[5])
-grna_assignment_method <- args[6]
-threshold <- args[7]
-n_em_rep <- args[8]
-n_nonzero_cells_cutoff <- args[9]
-backup_threshold <- args[10]
-probability_threshold <- args[11]
-grna_assignment_formula_fp <- args[12]
+grna_assignment_args_fp <- args[6]
+grna_assignment_formula_fp <- args[7]
 
 # load the sceptre object
 sceptre_object <- sceptre::read_ondisc_backed_sceptre_object(sceptre_object_fp = sceptre_object_fp,
@@ -30,22 +25,18 @@ grnas_in_use <- subset(grna_to_pod_map, pod_id == grna_pod)$grna_id
 sceptre_object@elements_to_analyze <- grnas_in_use
 sceptre_object@nf_pipeline <- TRUE
 
-# process the default arguments
-args_to_pass <- list(sceptre_object = sceptre_object,
-                     method = grna_assignment_method,
-                     parallel = FALSE)
-optional_args_names <- c("threshold", "n_em_rep", "n_nonzero_cells_cutoff",
-                         "backup_threshold", "probability_threshold")
-for (optional_arg_name in optional_args_names) {
-  optional_arg_value <- get(x = optional_arg_name)
-  if (!identical(optional_arg_value, "default")) {
-    args_to_pass[[optional_arg_name]] <- as.numeric(optional_arg_value)
-  }
-}
+# load the arguments resolved by the one-time preparation step; Nextflow stages
+# the user-supplied formula only when that step determines it is applicable
+grna_assignment_args <- readRDS(grna_assignment_args_fp)
 grna_assignment_formula <- readRDS(grna_assignment_formula_fp)
 if (!identical(grna_assignment_formula, NULL)) {
-  args_to_pass[["formula_object"]] <- grna_assignment_formula
+  grna_assignment_args$formula_object <- grna_assignment_formula
 }
+args_to_pass <- c(
+  list(sceptre_object = sceptre_object),
+  grna_assignment_args,
+  list(parallel = FALSE)
+)
 
 # call the gRNA-to-cell assignment function
 sceptre_object <- do.call(what = sceptre::assign_grnas, args = args_to_pass)

--- a/bin/output_grna_info.R
+++ b/bin/output_grna_info.R
@@ -7,6 +7,15 @@ response_odm_fp <- args[2]
 grna_odm_fp <- args[3]
 grna_pod_size <- as.integer(args[4])
 trial <- as.logical(args[5])
+grna_assignment_method <- args[6]
+threshold <- args[7]
+umi_fraction_threshold <- args[8]
+min_grna_n_umis_threshold <- args[9]
+n_em_rep <- args[10]
+n_nonzero_cells_cutoff <- args[11]
+backup_threshold <- args[12]
+probability_threshold <- args[13]
+grna_assignment_formula_supplied <- as.logical(args[14])
 
 # load the sceptre object
 sceptre_object <- sceptre::read_ondisc_backed_sceptre_object(sceptre_object_fp = sceptre_object_fp,
@@ -18,7 +27,62 @@ grna_to_pod_map <- data.frame(grna_id = grnas_in_use,
                               pod_id = sceptre:::get_id_vect(grnas_in_use, grna_pod_size))
 grna_pods <- unique(grna_to_pod_map$pod_id)
 
+# resolve the gRNA assignment method and its arguments once, before the
+# assignment jobs are scattered across pods
+if (identical(grna_assignment_method, "default")) {
+  grna_assignment_method <- if (sceptre_object@low_moi) "maximum" else "mixture"
+}
+grna_assignment_arg_values <- list(
+  threshold = threshold,
+  umi_fraction_threshold = umi_fraction_threshold,
+  min_grna_n_umis_threshold = min_grna_n_umis_threshold,
+  n_em_rep = n_em_rep,
+  n_nonzero_cells_cutoff = n_nonzero_cells_cutoff,
+  backup_threshold = backup_threshold,
+  probability_threshold = probability_threshold
+)
+supplied_arg_names <- names(grna_assignment_arg_values)[
+  !vapply(grna_assignment_arg_values, identical, logical(1), "default")
+]
+if (grna_assignment_formula_supplied) {
+  supplied_arg_names <- c(supplied_arg_names, "grna_assignment_formula")
+}
+applicable_arg_names <- switch(
+  grna_assignment_method,
+  thresholding = "threshold",
+  mixture = c("n_em_rep", "n_nonzero_cells_cutoff", "backup_threshold",
+              "probability_threshold", "grna_assignment_formula"),
+  maximum = c("umi_fraction_threshold", "min_grna_n_umis_threshold"),
+  stop("Unrecognized gRNA assignment method: ", grna_assignment_method)
+)
+ignored_arg_names <- setdiff(supplied_arg_names, applicable_arg_names)
+active_arg_names <- intersect(supplied_arg_names, applicable_arg_names)
+grna_assignment_formula_in_use <-
+  "grna_assignment_formula" %in% active_arg_names
+grna_assignment_args <- list(method = grna_assignment_method)
+for (arg_name in setdiff(active_arg_names, "grna_assignment_formula")) {
+  grna_assignment_args[[arg_name]] <-
+    as.numeric(grna_assignment_arg_values[[arg_name]])
+}
+
 # write and save outputs
 sceptre:::write_vector(grna_pods, "grna_pods.txt")
 saveRDS(grna_to_pod_map, "grna_to_pod_map.rds")
-sceptre:::write_vector(tolower(sceptre_object@low_moi), "low_moi.txt")
+saveRDS(grna_assignment_args, "grna_assignment_args.rds")
+sceptre:::write_vector(grna_assignment_method, "grna_assignment_method.txt")
+sceptre:::write_vector(
+  tolower(grna_assignment_formula_in_use),
+  "grna_assignment_formula_in_use.txt"
+)
+warning_message <- if (length(ignored_arg_names) > 0L) {
+  paste0(
+    "Ignoring ", paste0("--", ignored_arg_names, collapse = ", "),
+    " because ",
+    if (length(ignored_arg_names) == 1L) "it does" else "they do",
+    " not apply to the ", grna_assignment_method,
+    " gRNA assignment method."
+  )
+} else {
+  character()
+}
+writeLines(warning_message, "grna_assignment_warning.txt")

--- a/bin/process_grna_assignments.R
+++ b/bin/process_grna_assignments.R
@@ -5,30 +5,22 @@ args <- commandArgs(trailingOnly = TRUE)
 sceptre_object_fp <- args[1]
 response_odm_fp <- args[2]
 grna_odm_fp <- args[3]
-method <- args[4]
-umi_fraction_threshold <- args[5]
-min_grna_n_umis_threshold <- args[6]
-grna_assignment_formula_fp <- args[7]
-grna_assignment_fps <- args[seq(8, length(args))]
+grna_assignment_args_fp <- args[4]
+grna_assignment_formula_fp <- args[5]
+grna_assignment_fps <- args[seq(6, length(args))]
 
 # load the sceptre object
 sceptre_object <- sceptre::read_ondisc_backed_sceptre_object(sceptre_object_fp = sceptre_object_fp,
                                                              response_odm_file_fp = response_odm_fp,
                                                              grna_odm_file_fp = grna_odm_fp)
-# determine the grna assignment method
-if (identical(method, "default")) method <- if (sceptre_object@low_moi) "maximum" else "mixture"
+# load the arguments resolved by the one-time preparation step
+grna_assignment_args <- readRDS(grna_assignment_args_fp)
+method <- grna_assignment_args$method
 
 # if method is maximum, carry out the standard assignment strategy
 if (method == "maximum") {
   sceptre_object@nf_pipeline <- FALSE
-  args_to_pass <- list(sceptre_object = sceptre_object, method = "maximum")
-  optional_args_names <- c("umi_fraction_threshold", "min_grna_n_umis_threshold")
-  for (optional_arg_name in optional_args_names) {
-    optional_arg_value <- get(x = optional_arg_name)
-    if (!identical(optional_arg_value, "default")) {
-      args_to_pass[[optional_arg_name]] <- as.numeric(optional_arg_value)
-    }
-  }
+  args_to_pass <- c(list(sceptre_object = sceptre_object), grna_assignment_args)
   sceptre_object <- do.call(sceptre::assign_grnas, args = args_to_pass)
 } else {
   # combine initial assignment list across grnas; update fields of sceptre_object

--- a/main.nf
+++ b/main.nf
@@ -138,18 +138,31 @@ process prepare_assign_grnas {
   path "sceptre_object_fp"
   path "response_odm_fp"
   path "grna_odm_fp"
+  val "grna_assignment_formula_supplied"
 
   output:
   path "grna_to_pod_map.rds", emit: grna_to_pod_map_ch
   path "grna_pods.txt", emit: grna_pods_ch
-  path "low_moi.txt", emit: low_moi_ch
+  path "grna_assignment_args.rds", emit: grna_assignment_args_ch
+  path "grna_assignment_method.txt", emit: grna_assignment_method_ch
+  path "grna_assignment_formula_in_use.txt", emit: grna_assignment_formula_in_use_ch
+  path "grna_assignment_warning.txt", emit: grna_assignment_warning_ch
 
   """
   output_grna_info.R $sceptre_object_fp \
   $response_odm_fp \
   $grna_odm_fp \
   ${params.grna_pod_size} \
-  ${params.trial}
+  ${params.trial} \
+  ${params.grna_assignment_method} \
+  ${params.threshold} \
+  ${params.umi_fraction_threshold} \
+  ${params.min_grna_n_umis_threshold} \
+  ${params.n_em_rep} \
+  ${params.n_nonzero_cells_cutoff} \
+  ${params.backup_threshold} \
+  ${params.probability_threshold} \
+  $grna_assignment_formula_supplied
   """
 }
 
@@ -159,10 +172,7 @@ process assign_grnas {
   memory params.assign_grnas_memory
 
   when:
-  !(params.grna_assignment_method == "maximum" || (low_moi == "true" && params.grna_assignment_method == "default"))
-  
-  //when:
-  //params.grna_assignment_method != "maximum"
+  grna_assignment_method != "maximum"
   
   input:
   path "sceptre_object_fp"
@@ -170,7 +180,8 @@ process assign_grnas {
   path "grna_odm_fp"
   path "grna_to_pod_map"
   val "grna_pod"
-  val "low_moi"
+  val "grna_assignment_method"
+  path "grna_assignment_args"
   path "grna_assignment_formula"
 
   output:
@@ -183,12 +194,7 @@ process assign_grnas {
   $grna_odm_fp \
   $grna_to_pod_map \
   $grna_pod \
-  ${params.grna_assignment_method} \
-  ${params.threshold} \
-  ${params.n_em_rep} \
-  ${params.n_nonzero_cells_cutoff} \
-  ${params.backup_threshold} \
-  ${params.probability_threshold} \
+  $grna_assignment_args \
   $grna_assignment_formula
   """
 }
@@ -199,14 +205,10 @@ process dummy_assign_grnas {
   memory "1GB"
   
   when:
-  params.grna_assignment_method == "maximum" || (low_moi == "true" && params.grna_assignment_method == "default")
-  
-  //when:
-  //params.grna_assignment_method == "maximum"
+  grna_assignment_method == "maximum"
 
   input:
-  path "sceptre_object_fp"
-  val "low_moi"
+  val "grna_assignment_method"
 
   output:
   path "grna_assignments.rds", emit: grna_assignments_ch
@@ -232,6 +234,7 @@ process combine_assign_grnas {
   path "sceptre_object_fp"
   path "response_odm_fp"
   path "grna_odm_fp"
+  path "grna_assignment_args"
   path "grna_assignment_formula"
   path "grna_assignments"
 
@@ -246,9 +249,7 @@ process combine_assign_grnas {
   process_grna_assignments.R $sceptre_object_fp \
   $response_odm_fp \
   $grna_odm_fp \
-  ${params.grna_assignment_method} \
-  ${params.umi_fraction_threshold} \
-  ${params.min_grna_n_umis_threshold} \
+  $grna_assignment_args \
   $grna_assignment_formula \
   grna_assignments*
   """
@@ -421,13 +422,27 @@ workflow {
   prepare_assign_grnas(
     set_analysis_parameters.out.sceptre_object_ch.first(),
     Channel.fromPath(params.response_odm_fp, checkIfExists : true),
-    Channel.fromPath(params.grna_odm_fp, checkIfExists : true)
+    Channel.fromPath(params.grna_odm_fp, checkIfExists : true),
+    params.grna_assignment_formula != "${baseDir}/resources/placeholder_file.rds"
   )
 
   // 3. process output from above process
   grna_to_pod_map_ch = prepare_assign_grnas.out.grna_to_pod_map_ch.first()
   grna_pods_ch = prepare_assign_grnas.out.grna_pods_ch.splitText().map{it.trim()}
-  low_moi_ch = prepare_assign_grnas.out.low_moi_ch.splitText().map{it.trim()}.first()
+  grna_assignment_args_ch = prepare_assign_grnas.out.grna_assignment_args_ch.first()
+  grna_assignment_method_ch = prepare_assign_grnas.out.grna_assignment_method_ch.splitText().map{it.trim()}.first()
+  grna_assignment_formula_in_use_ch = prepare_assign_grnas.out.grna_assignment_formula_in_use_ch.splitText().map{it.trim() == "true"}.first()
+  grna_assignment_formula_input_ch = grna_assignment_formula_in_use_ch.map{in_use ->
+    file(
+      in_use ? params.grna_assignment_formula : "${baseDir}/resources/placeholder_file.rds",
+      checkIfExists : true
+    )
+  }
+  prepare_assign_grnas.out.grna_assignment_warning_ch
+    .splitText()
+    .map{it.trim()}
+    .filter{it}
+    .subscribe{log.warn(it)}
 
   // 4. assign gRNAs
   assign_grnas(
@@ -436,12 +451,12 @@ workflow {
     Channel.fromPath(params.grna_odm_fp).first(),
     grna_to_pod_map_ch,
     grna_pods_ch,
-    low_moi_ch,
-    Channel.fromPath(params.grna_assignment_formula).first()
+    grna_assignment_method_ch,
+    grna_assignment_args_ch,
+    grna_assignment_formula_input_ch
   )
   dummy_assign_grnas(
-    set_analysis_parameters.out.sceptre_object_ch.first(),
-    low_moi_ch
+    grna_assignment_method_ch
   )
   
   // 5. process output from above process
@@ -453,6 +468,7 @@ workflow {
     set_analysis_parameters.out.sceptre_object_ch.first(),
     Channel.fromPath(params.response_odm_fp).first(),
     Channel.fromPath(params.grna_odm_fp).first(),
+    grna_assignment_args_ch,
     grna_assignment_formula_ch,
     grna_assignments_ch
   )


### PR DESCRIPTION
## Summary

- resolve the effective gRNA assignment method once before assignment jobs are scattered
- pass only method-applicable arguments to `sceptre::assign_grnas()`
- emit one Nextflow warning that names supplied but inapplicable arguments
- defer formula-path validation until the resolved method actually uses the formula

## Root cause

The pipeline forwarded every non-default assignment option to `sceptre::assign_grnas()`, regardless of the selected assignment method. Consequently, a mixture-only option such as `--n_nonzero_cells_cutoff` caused thresholding to fail because the package correctly requires thresholding hyperparameters to contain only `threshold`.

## User impact

Known assignment options that do not apply to the selected method are now ignored with a single visible warning. Applicable options retain their existing validation, including formula-file existence checks and package-level hyperparameter checks.

Addresses Katsevich-Lab/sceptre#159.

## Validation

- completed a 60-pod thresholding run with three irrelevant options and exactly one warning
- completed explicit mixture and maximum runs, including mixture with a custom formula
- verified `method = "default"` resolves to mixture for high-MOI data and maximum for low-MOI data
- verified applicable-only inputs emit no warning
- verified invalid active options still fail package validation
- verified missing formula paths are ignored only when the formula is inapplicable
- parsed all modified R scripts and ran `git diff --check`
